### PR TITLE
ignore special files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaycom/apps-cli",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "A cli tool to manage apps (and monday-code projects) in monday.com",
   "author": "monday.com Apps Team",
   "type": "module",

--- a/src/services/files-service.ts
+++ b/src/services/files-service.ts
@@ -37,8 +37,11 @@ export const createTarGzArchive = async (directoryPath: string, fileName = 'code
 
     const archivePath = `${directoryPath}/${fileName}.tar.gz`;
     const fullFileName = `**/${fileName}.tar.gz`;
+
+    // a special list of files to ignore that are not in .gitignore that is may or may not be in the project
+    const additionalFilesToIgnore = ['.git/**', '.env', 'local-secure-storage.db.json', '.mappsrc'];
     const pathsToIgnoreFromGitIgnore = getFilesToExcludeForArchive(directoryPath);
-    const pathsToIgnore = [...pathsToIgnoreFromGitIgnore, archivePath, fullFileName];
+    const pathsToIgnore = [...pathsToIgnoreFromGitIgnore, archivePath, fullFileName, ...additionalFilesToIgnore];
 
     await compressDirectoryToTarGz(directoryPath, archivePath, pathsToIgnore);
     return archivePath;


### PR DESCRIPTION
so it appears that this glob pattern that we have in the same file doesn't catch all patterns, so we need to add it manually
```
    archive.glob('**/*', {
      cwd: directoryPath,
      ignore: pathsToIgnore,
      nodir: true,
      dot: true,
    });

```