### PR TITLE
Increase timeout for client-side zip upload to 60 seconds

### DIFF
--- a/src/services/push-service.ts
+++ b/src/services/push-service.ts
@@ -70,7 +70,7 @@ export const uploadClientZipFile = async (appVersionId: number, buffer: Buffer) 
     headers: { Accept: 'application/json', 'Content-Type': 'multipart/form-data' },
     method: HttpMethodTypes.POST,
     body: formData,
-    timeout: CLIENT_ZIP_UPLOAD_TIMEOUT
+    timeout: CLIENT_ZIP_UPLOAD_TIMEOUT,
   });
   return response.data;
 };


### PR DESCRIPTION
Users can deploy their client-side code via CLI now. 

Previously, this used the default timeout of the `api-service` which is 10 seconds. This is too short for slow internet connections. 

I increased it to 60 seconds for this specific request. AFAIK 60s is the standard for most requests to our platform. 

Received this feedback from our community here: https://mondaymarketp.slack.com/archives/C05HD6QLV9Q/p1750879234814949?thread_ts=1748539800.596439&cid=C05HD6QLV9Q