### PR TITLE
 fix/idanluf/scaffold-promise-fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaycom/apps-cli",
-  "version": "4.9.3-beta.2",
+  "version": "4.9.3",
   "description": "A cli tool to manage apps (and monday-code projects) in monday.com",
   "author": "monday.com Apps Team",
   "type": "module",

--- a/src/commands/app/scaffold.ts
+++ b/src/commands/app/scaffold.ts
@@ -142,7 +142,7 @@ export default class AppScaffold extends BaseCommand {
         `To run manually later:\n` +
         `  cd ${ctx.project.name}\n` +
         `  npm run ${ctx.startCommand}\n\n` +
-        `Press Enter to enter access token and view the tunnel URL\n\n`,
+        `Press Enter to provide your access token and view the tunnel URL\n`,
     );
 
     // Keep scaffold process alive so dev server continues running


### PR DESCRIPTION
 Removed cleanup handlers that were killing the child process
keep scaffold command alive until the user manually stops