### PR TITLE
Enhance mondaycodercSchema validation for Java runtime versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaycom/apps-cli",
-  "version": "4.10.5",
+  "version": "4.10.6-beta.0",
   "description": "A cli tool to manage apps (and monday-code projects) in monday.com",
   "author": "monday.com Apps Team",
   "type": "module",

--- a/src/services/__tests__/mondaycoderc-schema.test.ts
+++ b/src/services/__tests__/mondaycoderc-schema.test.ts
@@ -12,8 +12,13 @@ describe('mondaycodercSchema Validation', () => {
   });
 
   it('should validate a correct Java runtime and version', () => {
-    const data = { RUNTIME: 'Java', RUNTIME_VERSION: '17' };
+    const data = { RUNTIME: 'Java', RUNTIME_VERSION: '17.0.1' };
     expect(() => mondaycodercSchema.parse(data)).not.toThrow();
+  });
+
+  it('should invalidate a Java version that is just a number', () => {
+    const data = { RUNTIME: 'Java', RUNTIME_VERSION: '17' };
+    expect(() => mondaycodercSchema.parse(data)).toThrow('Invalid RUNTIME_VERSION');
   });
 
   it('should validate a missing runtime version when runtime is specified', () => {

--- a/src/services/schemas/mondaycoderc-schema.ts
+++ b/src/services/schemas/mondaycoderc-schema.ts
@@ -28,8 +28,10 @@ export const mondaycodercSchema = z
 
       if (data.RUNTIME === 'Java') {
         // 8, 11, 17, 21 are the only LTS versions, see https://www.oracle.com/eg/java/technologies/java-se-support-roadmap.html
-        if (!['8', '11', '17', '21'].includes(data.RUNTIME_VERSION || '')) {
-          throw new Error('Invalid RUNTIME_VERSION for Java in .mondaycoderc. Allowed versions are 8, 11, 17, 21');
+        if (!/^(8|11|17|21)\.\d+\.\d+$/.test(data.RUNTIME_VERSION || '')) {
+          throw new Error(
+            'Invalid RUNTIME_VERSION for Java in .mondaycoderc. Allowed versions are 8.x.x, 11.x.x, 17.x.x, 21.x.x',
+          );
         }
 
         return true;


### PR DESCRIPTION
- Updated the schema to require Java version format to be 'x.x.x' for valid LTS versions (8, 11, 17, 21).
- Added a test case to ensure that a Java version specified as just a number (e.g., '17') is invalid.
- Adjusted existing test to validate the new version format.