### PR TITLE
feat: add tokenCommand hook for secrets manager integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,70 @@ USAGE
 
 <!-- usagestop -->
 
+# Authentication
+
+## Basic setup
+
+```sh-session
+$ mapps init -t YOUR_ACCESS_TOKEN
+```
+
+## Secrets manager integration
+
+Instead of storing a plaintext token in `.mappsrc`, you can configure a shell command that fetches the token from any secrets manager at runtime. The command must print the token to stdout.
+
+```sh-session
+# Configure with a single account
+$ mapps init --token-command 'op read op://vault/monday-dev/token'
+
+# Configure with named credentials for switching between accounts
+$ mapps init --token-command 'op read op://vault/{{name}}/token' --default-token-name monday-dev
+```
+
+Then use `--token-name` (`-n`) on any command to override the default:
+
+```sh-session
+# Uses defaultTokenName ("monday-dev")
+$ mapps code:status
+
+# Override with a different account
+$ mapps code:status -n monday-prod
+```
+
+### Supported secrets managers
+
+Any CLI that outputs a token to stdout works. Examples:
+
+| Provider | tokenCommand |
+|----------|-------------|
+| 1Password | `op read op://vault/{{name}}/token` |
+| Bitwarden | `bw get password {{name}}` |
+| LastPass | `lpass show --password {{name}}` |
+| HashiCorp Vault | `vault kv get -field=token secret/monday/{{name}}` |
+| AWS Secrets Manager | `aws secretsmanager get-secret-value --secret-id {{name}} --query SecretString --output text` |
+| macOS Keychain | `security find-generic-password -s {{name}} -w` |
+| Linux libsecret | `secret-tool lookup service monday account {{name}}` |
+| pass (GPG) | `pass monday/{{name}}` |
+
+### Error handling
+
+If `tokenCommand` is configured and fails (command error, empty output, or missing `{{name}}`), the CLI will exit with an error instead of silently falling back. This ensures you know immediately if your secrets manager is misconfigured or unavailable.
+
+To bypass `tokenCommand` and fall back to the `accessToken` in `.mappsrc`:
+
+```sh-session
+$ mapps code:status --ignore-token-command
+```
+
+### Precedence
+
+Token resolution follows this order (highest to lowest):
+
+1. `--token-name` flag (resolves via `tokenCommand` template)
+2. `tokenCommand` in `.mappsrc` (with optional `defaultTokenName` substitution)
+3. `accessToken` in `.mappsrc` (plaintext fallback)
+4. Interactive prompt via `mapps init`
+
 # Commands
 
 <!-- commands -->

--- a/src/commands-base/authenticated-command.ts
+++ b/src/commands-base/authenticated-command.ts
@@ -18,6 +18,12 @@ const validateAccessToken = async (config: Config): Promise<void> => {
 export abstract class AuthenticatedCommand extends BaseCommand {
   public async init(): Promise<void> {
     await super.init();
+    const { flags } = await this.parse(this.constructor as typeof AuthenticatedCommand);
+    const tokenName = flags['token-name'] as string | undefined;
+    if (tokenName) {
+      ConfigService.resolveAndSetToken(tokenName);
+    }
+
     await validateAccessToken(this.config);
   }
 

--- a/src/commands-base/base-command.ts
+++ b/src/commands-base/base-command.ts
@@ -51,6 +51,18 @@ export abstract class BaseCommand extends Command {
       default: false,
       helpGroup: 'global',
     }),
+
+    'token-name': Flags.string({
+      char: 'n',
+      description: 'Named credential to resolve via tokenCommand (substitutes {{name}} in the command).',
+      helpGroup: 'global',
+    }),
+
+    'ignore-token-command': Flags.boolean({
+      description: 'Skip tokenCommand resolution and use accessToken from .mappsrc instead.',
+      default: false,
+      helpGroup: 'global',
+    }),
   };
 
   protected catch(err: Error & { exitCode?: number }): any {

--- a/src/commands/init/index.ts
+++ b/src/commands/init/index.ts
@@ -6,7 +6,7 @@ import { CONFIG_NAME, ConfigService } from 'services/config-service';
 import { getCurrentWorkingDirectory } from 'services/env-service';
 import { createGitignoreAndAppendConfigFileIfNeeded } from 'services/files-service';
 import { PromptService } from 'services/prompt-service';
-import { InitCommandArguments } from 'types/commands/init';
+import { ConfigData } from 'types/services/config-service';
 import logger from 'utils/logger';
 
 const accessTokenPrompt = async () =>
@@ -32,6 +32,12 @@ export default class Init extends BaseCommand {
       default: false,
       required: false,
     }),
+    'token-command': Flags.string({
+      description: 'Shell command to fetch access token (stdout). Use {{name}} as placeholder for named credentials.',
+    }),
+    'default-token-name': Flags.string({
+      description: 'Default name to substitute into {{name}} in tokenCommand.',
+    }),
   });
 
   static args = {};
@@ -40,9 +46,16 @@ export default class Init extends BaseCommand {
   public async run(): Promise<void> {
     const { flags } = await this.parse(Init);
 
-    const args: InitCommandArguments = {
-      [CONFIG_KEYS.ACCESS_TOKEN]: flags.token || (await accessTokenPrompt()),
-    };
+    const configData: ConfigData = {};
+
+    if (flags['token-command']) {
+      configData.tokenCommand = flags['token-command'];
+      if (flags['default-token-name']) {
+        configData.defaultTokenName = flags['default-token-name'];
+      }
+    } else {
+      configData[CONFIG_KEYS.ACCESS_TOKEN] = flags.token || (await accessTokenPrompt());
+    }
 
     try {
       if (flags.local) {
@@ -50,7 +63,7 @@ export default class Init extends BaseCommand {
         createGitignoreAndAppendConfigFileIfNeeded(this.config.configDir);
       }
 
-      ConfigService.init(args, this.config.configDir, { override: true, setInProcessEnv: true });
+      ConfigService.init(configData, this.config.configDir, { override: true, setInProcessEnv: true });
       logger.info(`'${CONFIG_NAME}' created inside '${this.config.configDir}'`);
     } catch (error) {
       logger.debug(error, this.DEBUG_TAG);

--- a/src/consts/config.ts
+++ b/src/consts/config.ts
@@ -1,3 +1,5 @@
 export enum CONFIG_KEYS {
   ACCESS_TOKEN = 'accessToken',
+  TOKEN_COMMAND = 'tokenCommand',
+  DEFAULT_TOKEN_NAME = 'defaultTokenName',
 }

--- a/src/hooks/init.ts
+++ b/src/hooks/init.ts
@@ -12,7 +12,8 @@ export default function init(opts: Command) {
     opts.config.configDir = getCurrentWorkingDirectory();
   }
 
-  ConfigService.loadConfigToProcessEnv(opts.config.configDir);
+  const ignoreTokenCommand = opts.argv.includes('--ignore-token-command');
+  ConfigService.loadConfigToProcessEnv(opts.config.configDir, undefined, undefined, ignoreTokenCommand);
   if (opts.argv.includes('--verbose')) {
     enableDebugMode();
     logger.debug(`* Domain: ${getAppsDomain()} *`);

--- a/src/services/__tests__/config-service.test.ts
+++ b/src/services/__tests__/config-service.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it, beforeEach, afterEach } from '@jest/globals';
+import { existsSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { ConfigService, CONFIG_NAME } from 'services/config-service';
+
+describe('ConfigService', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `mapps-test-${Date.now()}`);
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    delete process.env.MONDAY_CODE_ACCESS_TOKEN;
+    delete process.env.MONDAY_CODE_TOKEN_COMMAND;
+    delete process.env.MONDAY_CODE_DEFAULT_TOKEN_NAME;
+
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  describe('loadConfigToProcessEnv', () => {
+    it('should load config file values into process.env', () => {
+      const configData = { accessToken: 'file-token' };
+      writeFileSync(join(testDir, CONFIG_NAME), JSON.stringify(configData), 'utf8');
+
+      ConfigService.loadConfigToProcessEnv(testDir);
+
+      expect(process.env.MONDAY_CODE_ACCESS_TOKEN).toBe('file-token');
+    });
+
+    it('should use accessToken from config when no tokenCommand is set', () => {
+      const configData = { accessToken: 'plain-token' };
+      writeFileSync(join(testDir, CONFIG_NAME), JSON.stringify(configData), 'utf8');
+
+      ConfigService.loadConfigToProcessEnv(testDir);
+
+      expect(process.env.MONDAY_CODE_ACCESS_TOKEN).toBe('plain-token');
+    });
+  });
+
+  describe('tokenCommand resolution', () => {
+    it('should resolve tokenCommand and set accessToken from its output', () => {
+      const configData = { tokenCommand: 'echo resolved-token' };
+      writeFileSync(join(testDir, CONFIG_NAME), JSON.stringify(configData), 'utf8');
+
+      ConfigService.loadConfigToProcessEnv(testDir);
+
+      expect(process.env.MONDAY_CODE_ACCESS_TOKEN).toBe('resolved-token');
+    });
+
+    it('should substitute {{name}} with defaultTokenName', () => {
+      const configData = {
+        tokenCommand: 'echo token-for-{{name}}',
+        defaultTokenName: 'my-dev-account',
+      };
+      writeFileSync(join(testDir, CONFIG_NAME), JSON.stringify(configData), 'utf8');
+
+      ConfigService.loadConfigToProcessEnv(testDir);
+
+      expect(process.env.MONDAY_CODE_ACCESS_TOKEN).toBe('token-for-my-dev-account');
+    });
+
+    it('should substitute {{name}} with explicit tokenName override', () => {
+      const configData = {
+        tokenCommand: 'echo token-for-{{name}}',
+        defaultTokenName: 'dev',
+      };
+      writeFileSync(join(testDir, CONFIG_NAME), JSON.stringify(configData), 'utf8');
+
+      ConfigService.loadConfigToProcessEnv(testDir, CONFIG_NAME, 'prod');
+
+      expect(process.env.MONDAY_CODE_ACCESS_TOKEN).toBe('token-for-prod');
+    });
+
+    it('should exit with error when tokenCommand fails', () => {
+      const configData = {
+        tokenCommand: 'false',
+        accessToken: 'fallback-token',
+      };
+      writeFileSync(join(testDir, CONFIG_NAME), JSON.stringify(configData), 'utf8');
+
+      expect(() => ConfigService.loadConfigToProcessEnv(testDir)).toThrow('process.exit(1)');
+    });
+
+    it('should exit with error when {{name}} is in tokenCommand but no name is provided', () => {
+      const configData = {
+        tokenCommand: 'echo token-for-{{name}}',
+      };
+      writeFileSync(join(testDir, CONFIG_NAME), JSON.stringify(configData), 'utf8');
+
+      expect(() => ConfigService.loadConfigToProcessEnv(testDir)).toThrow('process.exit(1)');
+    });
+
+    it('should skip tokenCommand when ignoreTokenCommand is true', () => {
+      const configData = {
+        tokenCommand: 'false',
+        accessToken: 'fallback-token',
+      };
+      writeFileSync(join(testDir, CONFIG_NAME), JSON.stringify(configData), 'utf8');
+
+      ConfigService.loadConfigToProcessEnv(testDir, CONFIG_NAME, undefined, true);
+
+      expect(process.env.MONDAY_CODE_ACCESS_TOKEN).toBe('fallback-token');
+    });
+  });
+
+  describe('resolveAndSetToken', () => {
+    it('should re-resolve tokenCommand with a new token name', () => {
+      process.env.MONDAY_CODE_TOKEN_COMMAND = 'echo token-for-{{name}}';
+      process.env.MONDAY_CODE_DEFAULT_TOKEN_NAME = 'dev';
+
+      ConfigService.resolveAndSetToken('staging');
+
+      expect(process.env.MONDAY_CODE_ACCESS_TOKEN).toBe('token-for-staging');
+    });
+
+    it('should do nothing when no tokenCommand is set', () => {
+      process.env.MONDAY_CODE_ACCESS_TOKEN = 'existing-token';
+
+      ConfigService.resolveAndSetToken('anything');
+
+      expect(process.env.MONDAY_CODE_ACCESS_TOKEN).toBe('existing-token');
+    });
+  });
+
+  describe('init', () => {
+    it('should write tokenCommand to config file', () => {
+      ConfigService.init(
+        { tokenCommand: 'echo my-token', defaultTokenName: 'dev' },
+        testDir,
+        { setInProcessEnv: true },
+      );
+
+      expect(process.env.MONDAY_CODE_TOKEN_COMMAND).toBe('echo my-token');
+      expect(process.env.MONDAY_CODE_DEFAULT_TOKEN_NAME).toBe('dev');
+    });
+  });
+});

--- a/src/services/config-service.ts
+++ b/src/services/config-service.ts
@@ -1,3 +1,4 @@
+import { execSync } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
@@ -43,6 +44,40 @@ const setConfigDataInProcessEnv = (data: ConfigData) => {
   }
 };
 
+const resolveTokenCommand = (data: ConfigData, tokenName?: string): ConfigData => {
+  if (!data.tokenCommand) return data;
+
+  let command = data.tokenCommand;
+  const name = tokenName || data.defaultTokenName;
+  const hasPlaceholder = command.includes('{{name}}');
+
+  if (hasPlaceholder && !name) {
+    logger.error(
+      'tokenCommand contains {{name}} but no token name was provided. ' +
+        'Use --token-name or set defaultTokenName in .mappsrc.',
+    );
+    return process.exit(1);
+  }
+
+  if (name) {
+    command = command.replaceAll('{{name}}', name);
+  }
+
+  try {
+    const token = execSync(command, { encoding: 'utf8', timeout: 10_000 }).trim();
+    if (token) {
+      return { ...data, accessToken: token };
+    }
+
+    logger.error('tokenCommand returned an empty token.');
+    return process.exit(1);
+  } catch (error) {
+    logger.error(`tokenCommand failed: ${(error as Error).message}`);
+    logger.error('Use --ignore-token-command to bypass, or fix your tokenCommand configuration.');
+    return process.exit(1);
+  }
+};
+
 const readConfig = (directoryPath: string, fileName = CONFIG_NAME) => {
   if (!checkConfigExists(directoryPath, fileName)) {
     throw new BadConfigError(`the file: ${fileName} is not found in ${directoryPath}`);
@@ -73,11 +108,27 @@ export const ConfigService = {
     return process.env[configKeyInProcessEnv] as string;
   },
 
-  loadConfigToProcessEnv(directoryPath: string, fileName = CONFIG_NAME) {
-    const data = readConfig(directoryPath, fileName);
+  loadConfigToProcessEnv(directoryPath: string, fileName = CONFIG_NAME, tokenName?: string, ignoreTokenCommand = false) {
+    let data = readConfig(directoryPath, fileName);
+    if (!ignoreTokenCommand) {
+      data = resolveTokenCommand(data, tokenName);
+    }
+
     setConfigDataInProcessEnv(data);
 
     return data;
+  },
+
+  resolveAndSetToken(tokenName?: string) {
+    const tokenCommand = process.env[generateConfigKeyInProcessEnv('tokenCommand' as keyof ConfigData)];
+    const defaultTokenName = process.env[generateConfigKeyInProcessEnv('defaultTokenName' as keyof ConfigData)];
+    if (!tokenCommand) return;
+
+    const data = resolveTokenCommand({ tokenCommand, defaultTokenName }, tokenName);
+    if (data.accessToken) {
+      const key = generateConfigKeyInProcessEnv('accessToken' as keyof ConfigData);
+      process.env[key] = data.accessToken;
+    }
   },
 
   removeConfig(directoryPath: string, fileName = CONFIG_NAME) {

--- a/src/types/services/config-service.ts
+++ b/src/types/services/config-service.ts
@@ -6,4 +6,6 @@ export type InitConfigOptions = Partial<{
 
 export type ConfigData = Partial<{
   accessToken: string;
+  tokenCommand: string;
+  defaultTokenName: string;
 }>;


### PR DESCRIPTION
## Summary

- Adds `tokenCommand` config field that executes a shell command at runtime to fetch the access token from any secrets manager
- Supports `{{name}}` placeholder with optional `defaultTokenName` for switching between accounts
- Adds `--token-name` (`-n`) global flag on all commands for overriding the default credential
- tokenCommand failures are hard errors to catch misconfigurations immediately
- Adds `--ignore-token-command` global flag to bypass the hook when needed

Closes #157

## Changes

- `src/consts/config.ts`: New `TOKEN_COMMAND` and `DEFAULT_TOKEN_NAME` config keys
- `src/types/services/config-service.ts`: New `tokenCommand` and `defaultTokenName` fields on `ConfigData`
- `src/services/config-service.ts`: `resolveTokenCommand` function with `{{name}}` substitution, error handling, and `resolveAndSetToken` public method
- `src/hooks/init.ts`: Passes `--ignore-token-command` flag through to config loading
- `src/commands-base/base-command.ts`: `--token-name` and `--ignore-token-command` shared flags
- `src/commands-base/authenticated-command.ts`: Re-resolves tokenCommand when `--token-name` is provided
- `src/commands/init/index.ts`: `--token-command` and `--default-token-name` flags, skips token prompt when tokenCommand is provided
- `README.md`: Authentication section documenting secrets manager integration
- `src/services/__tests__/config-service.test.ts`: 11 tests covering resolution, substitution, error handling, and ignore flag

## Test plan

- [x] All non-integration tests pass (11 suites, 52 tests)
- [x] New config-service tests cover: resolution, `{{name}}` substitution, explicit override, command failure, missing name error, ignore flag
- [x] Manual: configured `tokenCommand` with 1Password `op read`, verified token resolution works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)