### PR TITLE
fix: manifest:export treats file paths as directories and silently overwrites

### DIFF
--- a/pr-160.md
+++ b/pr-160.md
@@ -1,0 +1,52 @@
+# feat: add credential profiles for secrets manager integration
+
+> **Status: Withdrawn pending CVE-2025-69262 mitigation**
+>
+> This PR is closed until env var reference injection in profile command strings is addressed.
+> See CVE-2025-69262 for context on the attack vector.
+
+Closes #159
+
+## Summary
+
+- Add named credential profiles to `.mappsrc` that execute shell commands to fetch tokens at runtime, keeping plaintext tokens off disk
+- Add `mapps profile` interactive command and `profile:add`, `profile:remove`, `profile:list`, `profile:set-default`, `profile:clear-default`, `profile:remove-token` subcommands
+- Add global `--profile` and `--ignore-profiles` flags to all commands
+- Profiles are global-config only — local project `.mappsrc` profiles are ignored with a warning to prevent command injection from malicious repositories
+- 35 unit tests covering ConfigService profile resolution, profile subcommands, and authenticated command auth flow
+
+This is fully backwards compatible — existing `.mappsrc` files and the plaintext `mapps init` workflow continue to work unchanged. The goal is not to remove the plaintext option, but to ensure developers have a secure alternative available so that storing credentials on disk becomes an informed choice rather than the only path offered by the tool.
+
+Note: this also includes the env var precedence fix from #156 — pre-existing `MONDAY_CODE_ACCESS_TOKEN` env vars are no longer overwritten by `.mappsrc` config values. This is needed for correctness when profiles coexist with externally set tokens (e.g. CI). If #156 merges first, the conflict on `setConfigDataInProcessEnv` will be trivial to resolve.
+
+## Config format
+
+```json
+{
+  "profiles": {
+    "dev": "op read 'op://vault/dev/credential'",
+    "prod": "echo PROD_TOKEN_HERE"
+  },
+  "defaultProfile": "dev"
+}
+```
+
+## Test plan
+
+- [x] `mapps profile:add --name dev --command "echo token" --set-as-default` writes correct config
+- [x] `mapps profile:list` displays profiles with default indicator
+- [x] `mapps profile:remove --name dev` removes profile and clears default if it was the default
+- [x] `mapps profile:set-default --name prod` updates defaultProfile
+- [x] `mapps profile:clear-default` removes defaultProfile
+- [x] `mapps profile:remove-token` removes legacy plaintext accessToken
+- [x] `mapps profile` interactive flow works for add/remove/set-default/clear-default/list
+- [x] `mapps code:push --profile prod` resolves the named profile at runtime
+- [x] `mapps code:push --ignore-profiles` skips profile resolution
+- [x] Profile command failure aborts with actionable error message
+- [x] Missing profile name aborts with available profiles listed
+- [x] No default set + no --profile flag prompts for profile selection interactively
+- [x] Externally set env var (CI) skips profile prompt and uses the env var
+- [x] First-run auth flow offers choice between profile and plaintext, then continues original command
+- [x] Local .mappsrc with profiles triggers warning and profiles are ignored
+- [x] No command ID (oclif tooling, help) skips profile resolution
+- [x] 35 unit tests pass (16 ConfigService + 16 profile subcommands + 3 authenticated command)

--- a/profile-security.md
+++ b/profile-security.md
@@ -1,0 +1,185 @@
+# Credential Profile Security: Known Issues and Required Mitigations
+
+## Background
+
+The credential profiles feature (`mapps profile`) stores named commands in `.mappsrc` that are executed at runtime to fetch access tokens from secrets managers (1Password, Vault, AWS Secrets Manager, etc.). A profile entry looks like:
+
+```json
+{
+  "profiles": {
+    "dev": "/usr/local/bin/op read op://vault/monday-dev/token"
+  },
+  "defaultProfile": "dev"
+}
+```
+
+At runtime, the stored command is split on whitespace into `[cmd, ...args]` and executed via `execFileSync` (no shell). Its stdout is used as the access token.
+
+This design is directly analogous to pnpm's `tokenHelper` feature, which was affected by **CVE-2025-69262**. We adopt pnpm's security model as our baseline and add additional write-time validation since we control the add flow (pnpm doesn't — `.npmrc` is hand-edited).
+
+---
+
+## CVE-2025-69262 — pnpm tokenHelper Injection
+
+**CVSS:** 7.5 HIGH
+**CWEs:** CWE-78 (OS Command Injection), CWE-94 (Code Injection)
+**Affected versions:** pnpm 6.25.0 – 10.26.x
+**Fixed in:** pnpm 10.27.0
+
+### Attack vector
+
+pnpm's `.npmrc` supports `${VAR}` syntax for environment variable expansion. The `tokenHelper` setting specifies an executable and optional arguments. The vulnerable code path was:
+
+1. Read `tokenHelper` value from `.npmrc`
+2. Expand `${VAR}` references using the current process environment
+3. Execute the resulting string with `spawnSync(helperPath, { shell: true })`
+
+An attacker who can inject or influence environment variables — common in CI/CD pipelines via pull request builds, poisoned workflow env, compromised runner dependencies — can redirect the helper to an arbitrary executable or inject shell metacharacters into the expanded value.
+
+### pnpm's security model (post-fix, from source)
+
+The actual pnpm implementation (`config/reader/src/parseCreds.ts`, `network/auth-header/src/getAuthHeadersFromConfig.ts`) uses three layers:
+
+1. **Reserved character blocking** — `$`, `%`, `` ` ``, `"`, `'` are rejected in the tokenHelper value. This prevents env var expansion (`$`, `%`), command substitution (`` ` ``), and quoting tricks (`"`, `'`).
+
+2. **Whitespace split into array** — the value is split on whitespace into `[cmd, ...args]`, a tuple type `TokenHelper = [string, ...string[]]`. Arguments are allowed.
+
+3. **`spawnSync(cmd, args, { shell: false })`** — the command is executed without a shell. This is the core security mechanism:
+   - Shell operators (`;`, `|`, `&&`, `||`, `>`, `<`) are inert bytes in argv, not operators
+   - No shell-level `$VAR` expansion occurs at execution time
+   - Each argument is a distinct argv entry passed directly to the process
+   - Arguments are safe because there is nothing to interpret them maliciously
+
+4. **Global config only** — project-level `.npmrc` `tokenHelper` entries are rejected.
+
+Note: pnpm's documentation states "absolute path, with no arguments" but the implementation and test suite allow both relative paths and arguments. The security guarantee comes from `shell: false` + character blocking, not from restricting path format or argument count.
+
+---
+
+## Our Design
+
+We adopt pnpm's runtime security model (reserved character blocking, whitespace split, `execFileSync` with no shell, global config only) and add write-time validation that pnpm cannot do (since `.npmrc` is hand-edited, but we control the `profile:add` flow).
+
+### Runtime security (matches pnpm)
+
+1. **Reserved characters** — `$`, `%`, `` ` ``, `"`, `'` are rejected in profile command values
+2. **Whitespace split** — command is split into `[cmd, ...args]`
+3. **`execFileSync(cmd, args)` with no shell** — the core security mechanism
+4. **Global config only** — local `.mappsrc` profiles are ignored with a warning (already implemented)
+
+### Write-time validation (our addition)
+
+Since `profile:add` is an interactive flow we control, we add two checks at add time that pnpm cannot enforce:
+
+1. **Resolve to absolute path** — when the user enters `op read op://vault/dev/token`, we run `which op` to resolve the binary to its absolute path (e.g. `/usr/local/bin/op`) and store the absolute path. This prevents PATH-hijacking attacks where an attacker places a malicious binary earlier in PATH. If `which` fails, we prompt for the full path.
+
+2. **Reject reserved characters and `${VAR}` patterns** — we check at add time and error immediately with a clear message, rather than waiting for runtime failure. This catches mistakes early.
+
+Users who manually edit `.mappsrc` bypass write-time validation, but runtime validation (reserved character check + `execFileSync` without shell) still protects them.
+
+### Arguments are allowed
+
+Arguments are safe because `execFileSync(cmd, args)` passes them as distinct argv entries directly to the process — no shell interprets them. This means `op read op://vault/dev/token` works directly without a wrapper script:
+
+```json
+{
+  "profiles": {
+    "dev": "/usr/local/bin/op read op://vault/monday-dev/token",
+    "prod": "/usr/local/bin/op read op://vault/monday-prod/token"
+  },
+  "defaultProfile": "dev"
+}
+```
+
+---
+
+## Validation
+
+### Reserved characters (runtime — checked on every execution)
+
+```typescript
+const RESERVED_CHARACTERS = new Set(['$', '%', '`', '"', "'"]);
+
+function validateReservedCharacters(command: string, profileName: string): void {
+  for (const char of command) {
+    if (RESERVED_CHARACTERS.has(char)) {
+      let hint = 'Try using a wrapper script whose command does not contain this character.';
+      if (char === '"' || char === "'") {
+        hint = `Quotation marks are not supported — arguments are split on whitespace and passed directly. ${hint}`;
+      } else if (char === '$' || char === '%') {
+        hint = `Environment variable references are not allowed for security reasons (CVE-2025-69262). ${hint}`;
+      }
+      throw new Error(
+        `Profile "${profileName}": unsupported character ${JSON.stringify(char)}. ${hint}`
+      );
+    }
+  }
+}
+```
+
+### Absolute path resolution (write-time — at `profile:add` only)
+
+```typescript
+import { execFileSync } from 'node:child_process';
+
+function resolveAbsolutePath(command: string): string {
+  const parts = command.split(/\s+/).filter(Boolean);
+  const cmd = parts[0];
+  const args = parts.slice(1);
+
+  if (cmd.startsWith('/')) {
+    return command; // already absolute
+  }
+
+  try {
+    const resolved = execFileSync('which', [cmd], { encoding: 'utf8' }).trim();
+    return [resolved, ...args].join(' ');
+  } catch {
+    throw new Error(
+      `Could not find "${cmd}" in PATH. Provide the full absolute path to the executable.`
+    );
+  }
+}
+```
+
+### Execution (runtime)
+
+```typescript
+import { execFileSync } from 'node:child_process';
+
+function executeProfile(command: string, profileName: string): string {
+  validateReservedCharacters(command, profileName);
+
+  const [cmd, ...args] = command.split(/\s+/).filter(Boolean);
+
+  const token = execFileSync(cmd, args, {
+    encoding: 'utf8',
+    timeout: 10_000,
+  }).trim();
+
+  if (!token) {
+    throw new Error(`Profile "${profileName}" returned an empty token.`);
+  }
+
+  return token;
+}
+```
+
+`execFileSync` does not invoke a shell. Shell operators are inert. Each argument is a distinct argv entry. This matches pnpm's `spawnSync(cmd, args, { shell: false })` model exactly.
+
+---
+
+## Files to Change When Implementing
+
+- `src/services/config-service.ts` — `resolveProfile()`: replace `execSync(command)` with the `executeProfile` pattern above (validate reserved chars, split on whitespace, `execFileSync` without shell)
+- `src/commands/profile/add.ts` — call `resolveAbsolutePath` before `saveConfig` to resolve and store absolute paths; call `validateReservedCharacters` to reject bad input early
+- `src/commands/profile/index.ts` — same validation in `ACTION_ADD_PROFILE` branch
+- `src/services/__tests__/config-service.test.ts` — add test cases: `$VAR` rejected, `${VAR}` rejected, backtick rejected, quote rejected, `%VAR%` rejected, valid command with args accepted, empty token rejected
+- `src/commands/profile/__tests__/profile.test.ts` — add test cases: `which` resolution at add time, reserved characters rejected at add time
+
+## UX
+
+- `profile:add` command prompt: `Command to fetch token (e.g. op read op://vault/dev/token)`
+- On add: resolve binary to absolute path automatically via `which`, confirm the stored value to the user
+- Example output: `Resolved "op" to /usr/local/bin/op. Profile "dev" saved.`
+- On reserved character error: tell the user exactly which character and why, suggest a wrapper script

--- a/src/commands/manifest/export.ts
+++ b/src/commands/manifest/export.ts
@@ -36,6 +36,11 @@ export default class ManifestExport extends AuthenticatedCommand {
       aliases: ['v'],
       description: MESSAGES.appVersionId,
     }),
+    force: Flags.boolean({
+      char: 'f',
+      description: 'Overwrite existing files without prompting',
+      default: false,
+    }),
   });
 
   DEBUG_TAG = 'manifest_export';
@@ -54,7 +59,7 @@ export default class ManifestExport extends AuthenticatedCommand {
   public async run(): Promise<void> {
     try {
       const { flags } = await this.parse(ManifestExport);
-      const { manifestPath, appId: appIdAsString, appVersionId: appVersionIdAsString } = flags;
+      const { manifestPath, appId: appIdAsString, appVersionId: appVersionIdAsString, force } = flags;
 
       let appId = appIdAsString ? Number(appIdAsString) : undefined;
       let appVersionId = appVersionIdAsString ? Number(appVersionIdAsString) : undefined;
@@ -76,7 +81,7 @@ export default class ManifestExport extends AuthenticatedCommand {
           { title: 'Validate app before exporting manifest', task: exportService.validateManifestTask },
           { title: 'Export app manifest', task: exportService.downloadManifestTask },
         ],
-        { ctx: { appVersionId, appId: appId!, manifestPath } },
+        { ctx: { appVersionId, appId: appId!, manifestPath, force } },
       );
 
       await tasks.run();

--- a/src/services/export-manifest-service.ts
+++ b/src/services/export-manifest-service.ts
@@ -1,3 +1,7 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
 import { ListrTaskWrapper } from 'listr2';
 
 import { exportAppManifestUrl, makeAppManifestExportableUrl } from 'consts/urls';
@@ -18,12 +22,44 @@ export const downloadManifestTask = async (
 ) => {
   task.output = `downloading manifest for app ${ctx.appId}`;
   const appManifest = await downloadManifest(ctx.appId, ctx.appVersionId);
-  const outputPath = ctx.manifestPath || `${ctx.appId}`;
-  await decompressZipBufferToFiles(Buffer.from(appManifest, 'base64'), outputPath);
+  const userPath = ctx.manifestPath || `${ctx.appId}`;
+  const isFilePath = path.extname(userPath) === '.json';
+  const outputDir = isFilePath ? path.dirname(userPath) || '.' : userPath;
+  const targetFile = isFilePath ? userPath : path.join(userPath, 'manifest.json');
+
+  if (fs.existsSync(targetFile)) {
+    // Clean up directories left by the previous buggy behavior that created directories instead of files
+    if (fs.statSync(targetFile).isDirectory()) {
+      if (!ctx.force) {
+        throw new Error(
+          `A directory exists at ${targetFile} (possibly from a previous export). Use --force to replace it.`,
+        );
+      }
+
+      fs.rmSync(targetFile, { recursive: true, force: true });
+    } else if (!ctx.force) {
+      throw new Error(`File already exists: ${targetFile}. Use --force to overwrite.`);
+    }
+  }
+
+  // Extract to a temp directory first to avoid overwriting existing files in the target
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mapps-manifest-'));
+  try {
+    await decompressZipBufferToFiles(Buffer.from(appManifest, 'base64'), tempDir);
+
+    if (!fs.existsSync(outputDir)) {
+      fs.mkdirSync(outputDir, { recursive: true });
+    }
+
+    const extractedFile = path.join(tempDir, 'manifest.json');
+    fs.copyFileSync(extractedFile, targetFile);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
 
   const currentWorkingDirectory = process.cwd();
-  const absolutePath = outputPath.startsWith('/') ? outputPath : `${currentWorkingDirectory}/${outputPath}`;
-  task.title = `your manifest files are downloaded at ${absolutePath}`;
+  const absolutePath = targetFile.startsWith('/') ? targetFile : `${currentWorkingDirectory}/${targetFile}`;
+  task.title = `manifest exported to ${absolutePath}`;
 };
 
 export const downloadManifest = async (appId: AppId, appVersionId?: AppVersionId) => {

--- a/src/services/export-manifest-service.ts
+++ b/src/services/export-manifest-service.ts
@@ -1,3 +1,7 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
 import { ListrTaskWrapper } from 'listr2';
 
 import { exportAppManifestUrl, makeAppManifestExportableUrl } from 'consts/urls';
@@ -15,12 +19,44 @@ export const downloadManifestTask = async (
 ) => {
   task.output = `downloading manifest for app ${ctx.appId}`;
   const appManifest = await downloadManifest(ctx.appId, ctx.appVersionId);
-  const outputPath = ctx.manifestPath || `${ctx.appId}`;
-  await decompressZipBufferToFiles(Buffer.from(appManifest, 'base64'), outputPath);
+  const userPath = ctx.manifestPath || `${ctx.appId}`;
+  const isFilePath = path.extname(userPath) === '.json';
+  const outputDir = isFilePath ? path.dirname(userPath) || '.' : userPath;
+  const targetFile = isFilePath ? userPath : path.join(userPath, 'manifest.json');
+
+  if (fs.existsSync(targetFile)) {
+    // Clean up directories left by the previous buggy behavior that created directories instead of files
+    if (fs.statSync(targetFile).isDirectory()) {
+      if (!ctx.force) {
+        throw new Error(
+          `A directory exists at ${targetFile} (possibly from a previous export). Use --force to replace it.`,
+        );
+      }
+
+      fs.rmSync(targetFile, { recursive: true, force: true });
+    } else if (!ctx.force) {
+      throw new Error(`File already exists: ${targetFile}. Use --force to overwrite.`);
+    }
+  }
+
+  // Extract to a temp directory first to avoid overwriting existing files in the target
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mapps-manifest-'));
+  try {
+    await decompressZipBufferToFiles(Buffer.from(appManifest, 'base64'), tempDir);
+
+    if (!fs.existsSync(outputDir)) {
+      fs.mkdirSync(outputDir, { recursive: true });
+    }
+
+    const extractedFile = path.join(tempDir, 'manifest.json');
+    fs.copyFileSync(extractedFile, targetFile);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
 
   const currentWorkingDirectory = process.cwd();
-  const absolutePath = outputPath.startsWith('/') ? outputPath : `${currentWorkingDirectory}/${outputPath}`;
-  task.title = `your manifest files are downloaded at ${absolutePath}`;
+  const absolutePath = targetFile.startsWith('/') ? targetFile : `${currentWorkingDirectory}/${targetFile}`;
+  task.title = `manifest exported to ${absolutePath}`;
 };
 
 export const downloadManifest = async (appId: AppId, appVersionId?: AppVersionId) => {

--- a/src/types/commands/manifest-export.ts
+++ b/src/types/commands/manifest-export.ts
@@ -4,4 +4,5 @@ export type ExportCommandTasksContext = {
   appId: AppId;
   appVersionId?: AppVersionId;
   manifestPath?: string;
+  force?: boolean;
 };


### PR DESCRIPTION
Closes #161

## Summary

- Fix `-p` flag treating file paths as directories when the path ends in `.json`
- Extract to a temp directory first, then copy to the final location to avoid corrupting existing files
- Add `--force` / `-f` flag to control overwrite behavior

**Note: This is a breaking change.** Scripts that rely on `-p ./path/file.json` creating a directory named `file.json` will break. The `--force` flag also means existing scripts that rely on silent overwrite behavior will need to add `-f`. This may be best suited for the next major version.

## Changes

- **`export-manifest-service.ts`** — detect `.json` paths as file targets, extract to temp dir, copy to final location, clean up temp dir in `finally` block
- **`manifest/export.ts`** — add `--force` / `-f` flag
- **`types/commands/manifest-export.ts`** — add `force` to context type

## Behavior

| Flag | Result |
|---|---|
| `-p ./examples/my-manifest.json` | Writes to `./examples/my-manifest.json` |
| `-p ./examples` | Writes `manifest.json` into `./examples/` directory |
| `-p my.app.exports` | Treated as directory (no `.json` extension) |
| No `-p` | Writes to `./<appId>/manifest.json` (unchanged) |
| Target exists, no `--force` | Aborts with error |
| Target exists, `--force` | Overwrites |

## Test plan

- [x] `-p ./path/to/output.json` creates a file, not a directory
- [x] `-p ./directory` preserves existing directory extraction behavior
- [x] Paths with non-`.json` extensions are treated as directories
- [x] Existing files are not overwritten without `--force`
- [x] `--force` allows overwriting existing files
- [x] Temp directory is cleaned up on success and failure
- [x] Cross-platform compatible (uses `os.tmpdir()`, `path.join`, no shell commands)