### PR TITLE
fix(manifest): clean up import temp zip and use tmpdir

### DIFF
--- a/pr-160.md
+++ b/pr-160.md
@@ -1,0 +1,52 @@
+# feat: add credential profiles for secrets manager integration
+
+> **Status: Withdrawn pending CVE-2025-69262 mitigation**
+>
+> This PR is closed until env var reference injection in profile command strings is addressed.
+> See CVE-2025-69262 for context on the attack vector.
+
+Closes #159
+
+## Summary
+
+- Add named credential profiles to `.mappsrc` that execute shell commands to fetch tokens at runtime, keeping plaintext tokens off disk
+- Add `mapps profile` interactive command and `profile:add`, `profile:remove`, `profile:list`, `profile:set-default`, `profile:clear-default`, `profile:remove-token` subcommands
+- Add global `--profile` and `--ignore-profiles` flags to all commands
+- Profiles are global-config only — local project `.mappsrc` profiles are ignored with a warning to prevent command injection from malicious repositories
+- 35 unit tests covering ConfigService profile resolution, profile subcommands, and authenticated command auth flow
+
+This is fully backwards compatible — existing `.mappsrc` files and the plaintext `mapps init` workflow continue to work unchanged. The goal is not to remove the plaintext option, but to ensure developers have a secure alternative available so that storing credentials on disk becomes an informed choice rather than the only path offered by the tool.
+
+Note: this also includes the env var precedence fix from #156 — pre-existing `MONDAY_CODE_ACCESS_TOKEN` env vars are no longer overwritten by `.mappsrc` config values. This is needed for correctness when profiles coexist with externally set tokens (e.g. CI). If #156 merges first, the conflict on `setConfigDataInProcessEnv` will be trivial to resolve.
+
+## Config format
+
+```json
+{
+  "profiles": {
+    "dev": "op read 'op://vault/dev/credential'",
+    "prod": "echo PROD_TOKEN_HERE"
+  },
+  "defaultProfile": "dev"
+}
+```
+
+## Test plan
+
+- [x] `mapps profile:add --name dev --command "echo token" --set-as-default` writes correct config
+- [x] `mapps profile:list` displays profiles with default indicator
+- [x] `mapps profile:remove --name dev` removes profile and clears default if it was the default
+- [x] `mapps profile:set-default --name prod` updates defaultProfile
+- [x] `mapps profile:clear-default` removes defaultProfile
+- [x] `mapps profile:remove-token` removes legacy plaintext accessToken
+- [x] `mapps profile` interactive flow works for add/remove/set-default/clear-default/list
+- [x] `mapps code:push --profile prod` resolves the named profile at runtime
+- [x] `mapps code:push --ignore-profiles` skips profile resolution
+- [x] Profile command failure aborts with actionable error message
+- [x] Missing profile name aborts with available profiles listed
+- [x] No default set + no --profile flag prompts for profile selection interactively
+- [x] Externally set env var (CI) skips profile prompt and uses the env var
+- [x] First-run auth flow offers choice between profile and plaintext, then continues original command
+- [x] Local .mappsrc with profiles triggers warning and profiles are ignored
+- [x] No command ID (oclif tooling, help) skips profile resolution
+- [x] 35 unit tests pass (16 ConfigService + 16 profile subcommands + 3 authenticated command)

--- a/profile-security.md
+++ b/profile-security.md
@@ -1,0 +1,185 @@
+# Credential Profile Security: Known Issues and Required Mitigations
+
+## Background
+
+The credential profiles feature (`mapps profile`) stores named commands in `.mappsrc` that are executed at runtime to fetch access tokens from secrets managers (1Password, Vault, AWS Secrets Manager, etc.). A profile entry looks like:
+
+```json
+{
+  "profiles": {
+    "dev": "/usr/local/bin/op read op://vault/monday-dev/token"
+  },
+  "defaultProfile": "dev"
+}
+```
+
+At runtime, the stored command is split on whitespace into `[cmd, ...args]` and executed via `execFileSync` (no shell). Its stdout is used as the access token.
+
+This design is directly analogous to pnpm's `tokenHelper` feature, which was affected by **CVE-2025-69262**. We adopt pnpm's security model as our baseline and add additional write-time validation since we control the add flow (pnpm doesn't — `.npmrc` is hand-edited).
+
+---
+
+## CVE-2025-69262 — pnpm tokenHelper Injection
+
+**CVSS:** 7.5 HIGH
+**CWEs:** CWE-78 (OS Command Injection), CWE-94 (Code Injection)
+**Affected versions:** pnpm 6.25.0 – 10.26.x
+**Fixed in:** pnpm 10.27.0
+
+### Attack vector
+
+pnpm's `.npmrc` supports `${VAR}` syntax for environment variable expansion. The `tokenHelper` setting specifies an executable and optional arguments. The vulnerable code path was:
+
+1. Read `tokenHelper` value from `.npmrc`
+2. Expand `${VAR}` references using the current process environment
+3. Execute the resulting string with `spawnSync(helperPath, { shell: true })`
+
+An attacker who can inject or influence environment variables — common in CI/CD pipelines via pull request builds, poisoned workflow env, compromised runner dependencies — can redirect the helper to an arbitrary executable or inject shell metacharacters into the expanded value.
+
+### pnpm's security model (post-fix, from source)
+
+The actual pnpm implementation (`config/reader/src/parseCreds.ts`, `network/auth-header/src/getAuthHeadersFromConfig.ts`) uses three layers:
+
+1. **Reserved character blocking** — `$`, `%`, `` ` ``, `"`, `'` are rejected in the tokenHelper value. This prevents env var expansion (`$`, `%`), command substitution (`` ` ``), and quoting tricks (`"`, `'`).
+
+2. **Whitespace split into array** — the value is split on whitespace into `[cmd, ...args]`, a tuple type `TokenHelper = [string, ...string[]]`. Arguments are allowed.
+
+3. **`spawnSync(cmd, args, { shell: false })`** — the command is executed without a shell. This is the core security mechanism:
+   - Shell operators (`;`, `|`, `&&`, `||`, `>`, `<`) are inert bytes in argv, not operators
+   - No shell-level `$VAR` expansion occurs at execution time
+   - Each argument is a distinct argv entry passed directly to the process
+   - Arguments are safe because there is nothing to interpret them maliciously
+
+4. **Global config only** — project-level `.npmrc` `tokenHelper` entries are rejected.
+
+Note: pnpm's documentation states "absolute path, with no arguments" but the implementation and test suite allow both relative paths and arguments. The security guarantee comes from `shell: false` + character blocking, not from restricting path format or argument count.
+
+---
+
+## Our Design
+
+We adopt pnpm's runtime security model (reserved character blocking, whitespace split, `execFileSync` with no shell, global config only) and add write-time validation that pnpm cannot do (since `.npmrc` is hand-edited, but we control the `profile:add` flow).
+
+### Runtime security (matches pnpm)
+
+1. **Reserved characters** — `$`, `%`, `` ` ``, `"`, `'` are rejected in profile command values
+2. **Whitespace split** — command is split into `[cmd, ...args]`
+3. **`execFileSync(cmd, args)` with no shell** — the core security mechanism
+4. **Global config only** — local `.mappsrc` profiles are ignored with a warning (already implemented)
+
+### Write-time validation (our addition)
+
+Since `profile:add` is an interactive flow we control, we add two checks at add time that pnpm cannot enforce:
+
+1. **Resolve to absolute path** — when the user enters `op read op://vault/dev/token`, we run `which op` to resolve the binary to its absolute path (e.g. `/usr/local/bin/op`) and store the absolute path. This prevents PATH-hijacking attacks where an attacker places a malicious binary earlier in PATH. If `which` fails, we prompt for the full path.
+
+2. **Reject reserved characters and `${VAR}` patterns** — we check at add time and error immediately with a clear message, rather than waiting for runtime failure. This catches mistakes early.
+
+Users who manually edit `.mappsrc` bypass write-time validation, but runtime validation (reserved character check + `execFileSync` without shell) still protects them.
+
+### Arguments are allowed
+
+Arguments are safe because `execFileSync(cmd, args)` passes them as distinct argv entries directly to the process — no shell interprets them. This means `op read op://vault/dev/token` works directly without a wrapper script:
+
+```json
+{
+  "profiles": {
+    "dev": "/usr/local/bin/op read op://vault/monday-dev/token",
+    "prod": "/usr/local/bin/op read op://vault/monday-prod/token"
+  },
+  "defaultProfile": "dev"
+}
+```
+
+---
+
+## Validation
+
+### Reserved characters (runtime — checked on every execution)
+
+```typescript
+const RESERVED_CHARACTERS = new Set(['$', '%', '`', '"', "'"]);
+
+function validateReservedCharacters(command: string, profileName: string): void {
+  for (const char of command) {
+    if (RESERVED_CHARACTERS.has(char)) {
+      let hint = 'Try using a wrapper script whose command does not contain this character.';
+      if (char === '"' || char === "'") {
+        hint = `Quotation marks are not supported — arguments are split on whitespace and passed directly. ${hint}`;
+      } else if (char === '$' || char === '%') {
+        hint = `Environment variable references are not allowed for security reasons (CVE-2025-69262). ${hint}`;
+      }
+      throw new Error(
+        `Profile "${profileName}": unsupported character ${JSON.stringify(char)}. ${hint}`
+      );
+    }
+  }
+}
+```
+
+### Absolute path resolution (write-time — at `profile:add` only)
+
+```typescript
+import { execFileSync } from 'node:child_process';
+
+function resolveAbsolutePath(command: string): string {
+  const parts = command.split(/\s+/).filter(Boolean);
+  const cmd = parts[0];
+  const args = parts.slice(1);
+
+  if (cmd.startsWith('/')) {
+    return command; // already absolute
+  }
+
+  try {
+    const resolved = execFileSync('which', [cmd], { encoding: 'utf8' }).trim();
+    return [resolved, ...args].join(' ');
+  } catch {
+    throw new Error(
+      `Could not find "${cmd}" in PATH. Provide the full absolute path to the executable.`
+    );
+  }
+}
+```
+
+### Execution (runtime)
+
+```typescript
+import { execFileSync } from 'node:child_process';
+
+function executeProfile(command: string, profileName: string): string {
+  validateReservedCharacters(command, profileName);
+
+  const [cmd, ...args] = command.split(/\s+/).filter(Boolean);
+
+  const token = execFileSync(cmd, args, {
+    encoding: 'utf8',
+    timeout: 10_000,
+  }).trim();
+
+  if (!token) {
+    throw new Error(`Profile "${profileName}" returned an empty token.`);
+  }
+
+  return token;
+}
+```
+
+`execFileSync` does not invoke a shell. Shell operators are inert. Each argument is a distinct argv entry. This matches pnpm's `spawnSync(cmd, args, { shell: false })` model exactly.
+
+---
+
+## Files to Change When Implementing
+
+- `src/services/config-service.ts` — `resolveProfile()`: replace `execSync(command)` with the `executeProfile` pattern above (validate reserved chars, split on whitespace, `execFileSync` without shell)
+- `src/commands/profile/add.ts` — call `resolveAbsolutePath` before `saveConfig` to resolve and store absolute paths; call `validateReservedCharacters` to reject bad input early
+- `src/commands/profile/index.ts` — same validation in `ACTION_ADD_PROFILE` branch
+- `src/services/__tests__/config-service.test.ts` — add test cases: `$VAR` rejected, `${VAR}` rejected, backtick rejected, quote rejected, `%VAR%` rejected, valid command with args accepted, empty token rejected
+- `src/commands/profile/__tests__/profile.test.ts` — add test cases: `which` resolution at add time, reserved characters rejected at add time
+
+## UX
+
+- `profile:add` command prompt: `Command to fetch token (e.g. op read op://vault/dev/token)`
+- On add: resolve binary to absolute path automatically via `which`, confirm the stored value to the user
+- Example output: `Resolved "op" to /usr/local/bin/op. Profile "dev" saved.`
+- On reserved character error: tell the user exactly which character and why, suggest a wrapper script

--- a/src/services/__tests__/import-manifest-service.test.ts
+++ b/src/services/__tests__/import-manifest-service.test.ts
@@ -1,7 +1,26 @@
-import { processManifestTemplate } from 'services/import-manifest-service';
-import { loadFile } from 'utils/file-system';
+import type { ListrTaskWrapper } from 'listr2';
 
-jest.mock('utils/file-system');
+import { execute } from 'services/api-service';
+import { compressFilesToZip, readZipFileAsBuffer } from 'services/files-service';
+import * as importManifestService from 'services/import-manifest-service';
+import { processManifestTemplate, uploadManifestTsk } from 'services/import-manifest-service';
+import type { ImportCommandTasksContext } from 'types/commands/manifest-import';
+import { loadFile, saveToFile, unlink } from 'utils/file-system';
+
+jest.mock('services/api-service', () => ({
+  execute: jest.fn().mockResolvedValue({}),
+}));
+
+jest.mock('services/files-service', () => ({
+  compressFilesToZip: jest.fn(),
+  readZipFileAsBuffer: jest.fn(),
+}));
+
+jest.mock('utils/file-system', () => ({
+  loadFile: jest.fn(),
+  saveToFile: jest.fn(),
+  unlink: jest.fn(),
+}));
 
 describe('processManifestTemplate', () => {
   const mockLoadFile = loadFile as jest.MockedFunction<typeof loadFile>;
@@ -31,5 +50,57 @@ describe('processManifestTemplate', () => {
     mockLoadFile.mockResolvedValue('{"key": "{{MISSING_VAR}}"}');
 
     await expect(processManifestTemplate(mockPath)).rejects.toThrow(/Missing variable/);
+  });
+});
+
+describe('uploadManifestTsk', () => {
+  const mockCompressFilesToZip = compressFilesToZip as jest.MockedFunction<typeof compressFilesToZip>;
+  const mockReadZipFileAsBuffer = readZipFileAsBuffer as jest.MockedFunction<typeof readZipFileAsBuffer>;
+  const mockSaveToFile = saveToFile as jest.MockedFunction<typeof saveToFile>;
+  const mockUnlink = unlink as jest.MockedFunction<typeof unlink>;
+  const mockExecute = execute as jest.MockedFunction<typeof execute>;
+
+  const zipPath = '/tmp/mapps-compress-test.zip';
+  // biome-ignore lint/suspicious/noExplicitAny: Listr renderer generic is unused by uploadManifestTsk
+  const taskStub = { output: '', title: '' } as unknown as ListrTaskWrapper<ImportCommandTasksContext, any>;
+
+  beforeEach(() => {
+    jest.spyOn(importManifestService, 'processManifestTemplate').mockResolvedValue({ name: 'test-app' });
+    mockCompressFilesToZip.mockResolvedValue(zipPath);
+    mockReadZipFileAsBuffer.mockReturnValue(Buffer.from('zip-bytes'));
+    mockSaveToFile.mockResolvedValue();
+    mockUnlink.mockResolvedValue();
+    mockExecute.mockResolvedValue({} as Awaited<ReturnType<typeof execute>>);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('unlinks the temp zip and processed manifest after a successful upload', async () => {
+    const ctx = {
+      manifestFilePath: '/project/manifest.json',
+      allowMissingVariables: false,
+      appId: 1 as const,
+    };
+
+    await uploadManifestTsk(ctx, taskStub);
+
+    expect(mockUnlink).toHaveBeenCalledWith(zipPath);
+    expect(mockUnlink).toHaveBeenCalledWith('/project/manifest.json.processed');
+  });
+
+  it('unlinks the temp zip and processed manifest when upload fails', async () => {
+    mockExecute.mockRejectedValueOnce(new Error('upload failed'));
+
+    const ctx = {
+      manifestFilePath: '/project/manifest.json',
+      allowMissingVariables: false,
+    };
+
+    await expect(uploadManifestTsk(ctx, taskStub)).rejects.toThrow('upload failed');
+
+    expect(mockUnlink).toHaveBeenCalledWith(zipPath);
+    expect(mockUnlink).toHaveBeenCalledWith('/project/manifest.json.processed');
   });
 });

--- a/src/services/__tests__/import-manifest-service.test.ts
+++ b/src/services/__tests__/import-manifest-service.test.ts
@@ -1,7 +1,26 @@
-import { processManifestTemplate } from 'services/import-manifest-service';
-import { loadFile } from 'utils/file-system';
+import type { ListrTaskWrapper } from 'listr2';
 
-jest.mock('utils/file-system');
+import { execute } from 'services/api-service';
+import { compressFilesToZip, readZipFileAsBuffer } from 'services/files-service';
+import * as importManifestService from 'services/import-manifest-service';
+import { processManifestTemplate, uploadManifestTsk } from 'services/import-manifest-service';
+import type { ImportCommandTasksContext } from 'types/commands/manifest-import';
+import { loadFile, saveToFile, unlink } from 'utils/file-system';
+
+jest.mock('services/api-service', () => ({
+  execute: jest.fn().mockResolvedValue({}),
+}));
+
+jest.mock('services/files-service', () => ({
+  compressFilesToZip: jest.fn(),
+  readZipFileAsBuffer: jest.fn(),
+}));
+
+jest.mock('utils/file-system', () => ({
+  loadFile: jest.fn(),
+  saveToFile: jest.fn(),
+  unlink: jest.fn(),
+}));
 
 describe('processManifestTemplate', () => {
   const mockLoadFile = loadFile as jest.MockedFunction<typeof loadFile>;
@@ -31,5 +50,57 @@ describe('processManifestTemplate', () => {
     mockLoadFile.mockResolvedValue('{"key": "{{MISSING_VAR}}"}');
 
     await expect(processManifestTemplate(mockPath)).rejects.toThrow(/Missing variable/);
+  });
+});
+
+describe('uploadManifestTsk', () => {
+  const mockCompressFilesToZip = compressFilesToZip as jest.MockedFunction<typeof compressFilesToZip>;
+  const mockReadZipFileAsBuffer = readZipFileAsBuffer as jest.MockedFunction<typeof readZipFileAsBuffer>;
+  const mockSaveToFile = saveToFile as jest.MockedFunction<typeof saveToFile>;
+  const mockUnlink = unlink as jest.MockedFunction<typeof unlink>;
+  const mockExecute = execute as jest.MockedFunction<typeof execute>;
+
+  const zipPath = '/tmp/mapps-compress-test.zip';
+  // biome-ignore lint/suspicious/noExplicitAny: Listr renderer generic is unused by uploadManifestTsk
+  const taskStub = { output: '', title: '' } as unknown as ListrTaskWrapper<ImportCommandTasksContext, any>;
+
+  beforeEach(() => {
+    jest.spyOn(importManifestService, 'processManifestTemplate').mockResolvedValue({ name: 'test-app' });
+    mockCompressFilesToZip.mockResolvedValue(zipPath);
+    mockReadZipFileAsBuffer.mockReturnValue(Buffer.from('zip-bytes'));
+    mockSaveToFile.mockResolvedValue(undefined);
+    mockUnlink.mockResolvedValue(undefined);
+    mockExecute.mockResolvedValue({} as Awaited<ReturnType<typeof execute>>);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('unlinks the temp zip and processed manifest after a successful upload', async () => {
+    const ctx = {
+      manifestFilePath: '/project/manifest.json',
+      allowMissingVariables: false,
+      appId: 1 as const,
+    };
+
+    await uploadManifestTsk(ctx, taskStub);
+
+    expect(mockUnlink).toHaveBeenCalledWith(zipPath);
+    expect(mockUnlink).toHaveBeenCalledWith('/project/manifest.json.processed');
+  });
+
+  it('unlinks the temp zip and processed manifest when upload fails', async () => {
+    mockExecute.mockRejectedValueOnce(new Error('upload failed'));
+
+    const ctx = {
+      manifestFilePath: '/project/manifest.json',
+      allowMissingVariables: false,
+    };
+
+    await expect(uploadManifestTsk(ctx, taskStub)).rejects.toThrow('upload failed');
+
+    expect(mockUnlink).toHaveBeenCalledWith(zipPath);
+    expect(mockUnlink).toHaveBeenCalledWith('/project/manifest.json.processed');
   });
 });

--- a/src/services/files-service.ts
+++ b/src/services/files-service.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -42,7 +43,7 @@ export const decompressZipBufferToFiles = async (buffer: Buffer, outputDir: stri
 };
 
 export const compressFilesToZip = async (files: { path: string; replaceName?: string }[]): Promise<string> => {
-  const tempZipPath = 'temp.zip';
+  const tempZipPath = path.join(os.tmpdir(), `mapps-compress-${randomUUID()}.zip`);
   const output = fs.createWriteStream(tempZipPath);
   const archive = archiver('zip', { zlib: { level: 9 } });
 

--- a/src/services/import-manifest-service.ts
+++ b/src/services/import-manifest-service.ts
@@ -17,18 +17,27 @@ export const uploadManifestTsk = async (
   ctx: ImportCommandTasksContext,
   task: ListrTaskWrapper<ImportCommandTasksContext, any>,
 ) => {
+  let zipFilePath: string | undefined;
   try {
     const processedManifest = await processManifestTemplate(ctx.manifestFilePath, ctx.allowMissingVariables);
     ctx.manifestFilePath = `${ctx.manifestFilePath}.processed`;
     await saveToFile(ctx.manifestFilePath, JSON.stringify(processedManifest));
 
     task.output = `Zipping your manifest file`;
-    const zipFilePath = await compressFilesToZip([{ path: ctx.manifestFilePath, replaceName: 'manifest.json' }]);
+    zipFilePath = await compressFilesToZip([{ path: ctx.manifestFilePath, replaceName: 'manifest.json' }]);
     const buffer = readZipFileAsBuffer(zipFilePath);
     task.output = `Uploading your app manifest`;
     await uploadZippedManifest(buffer, { appId: ctx.appId, appVersionId: ctx.appVersionId });
     task.output = `your app manifest has been uploaded successfully`;
   } finally {
+    if (zipFilePath) {
+      try {
+        await unlink(zipFilePath);
+      } catch {
+        // best-effort cleanup of temp zip
+      }
+    }
+
     await unlink(ctx.manifestFilePath);
   }
 };

--- a/src/services/import-manifest-service.ts
+++ b/src/services/import-manifest-service.ts
@@ -17,18 +17,26 @@ export const uploadManifestTsk = async (
   ctx: ImportCommandTasksContext,
   task: ListrTaskWrapper<ImportCommandTasksContext, any>,
 ) => {
+  let zipFilePath: string | undefined;
   try {
     const processedManifest = await processManifestTemplate(ctx.manifestFilePath, ctx.allowMissingVariables);
     ctx.manifestFilePath = `${ctx.manifestFilePath}.processed`;
     await saveToFile(ctx.manifestFilePath, JSON.stringify(processedManifest));
 
     task.output = `Zipping your manifest file`;
-    const zipFilePath = await compressFilesToZip([{ path: ctx.manifestFilePath, replaceName: 'manifest.json' }]);
+    zipFilePath = await compressFilesToZip([{ path: ctx.manifestFilePath, replaceName: 'manifest.json' }]);
     const buffer = readZipFileAsBuffer(zipFilePath);
     task.output = `Uploading your app manifest`;
     await uploadZippedManifest(buffer, { appId: ctx.appId, appVersionId: ctx.appVersionId });
     task.output = `your app manifest has been uploaded successfully`;
   } finally {
+    if (zipFilePath) {
+      try {
+        await unlink(zipFilePath);
+      } catch {
+        // best-effort cleanup of temp zip
+      }
+    }
     await unlink(ctx.manifestFilePath);
   }
 };


### PR DESCRIPTION
## Summary

- `compressFilesToZip` now writes to `os.tmpdir()` as `mapps-compress-<uuid>.zip` instead of a fixed `temp.zip` in the process cwd (avoids leftover files and concurrent clashes).
- `uploadManifestTsk` removes the zip path in `finally` (best-effort), then the existing `.processed` manifest cleanup.

## Tests

- `uploadManifestTsk`: assert `unlink` runs for both the zip path and `.processed` manifest on success and when upload fails after the zip is created.

Closes #163

Made with [Cursor](https://cursor.com)