### PR TITLE
chore: extend manifest import/export HTTP timeouts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaycom/apps-cli",
-  "version": "4.10.6",
+  "version": "4.10.7",
   "description": "A cli tool to manage apps (and monday-code projects) in monday.com",
   "author": "monday.com Apps Team",
   "type": "module",

--- a/src/services/export-manifest-service.ts
+++ b/src/services/export-manifest-service.ts
@@ -7,7 +7,10 @@ import { HttpError } from 'src/types/errors';
 import { ExportCommandTasksContext } from 'types/commands/manifest-export';
 import { AppId, AppVersionId } from 'types/general';
 import { HttpMethodTypes } from 'types/services/api-service';
+import { TIME_IN_MILLISECONDS } from 'utils/time-utils';
 import { appsUrlBuilder } from 'utils/urls-builder';
+
+const EXPORT_MANIFEST_HTTP_TIMEOUT_MS = TIME_IN_MILLISECONDS.MINUTE;
 
 export const downloadManifestTask = async (
   ctx: ExportCommandTasksContext,
@@ -31,6 +34,7 @@ export const downloadManifest = async (appId: AppId, appVersionId?: AppVersionId
     url,
     method: HttpMethodTypes.GET,
     query: { ...(appVersionId && { appVersionId }) },
+    timeout: EXPORT_MANIFEST_HTTP_TIMEOUT_MS,
   })) as any as { data: string };
 
   return response.data;
@@ -54,6 +58,7 @@ export const validateManifest = async (appId: AppId, appVersionId?: AppVersionId
       url,
       method: HttpMethodTypes.POST,
       query: { ...(appVersionId && { appVersionId }) },
+      timeout: EXPORT_MANIFEST_HTTP_TIMEOUT_MS,
     });
   } catch (error) {
     if (error instanceof HttpError && error.message.includes('Cannot create slugs for live version')) {

--- a/src/services/import-manifest-service.ts
+++ b/src/services/import-manifest-service.ts
@@ -122,7 +122,7 @@ const updateAppFromManifest = async (buffer: Buffer, appId: AppId, appVersionId?
     method: HttpMethodTypes.PUT,
     body: formData,
     query: { ...(appVersionId && { appVersionId }) },
-    timeout: TIME_IN_MILLISECONDS.SECOND * 30,
+    timeout: TIME_IN_MILLISECONDS.MINUTE * 2,
   });
   return response;
 };
@@ -138,7 +138,7 @@ const createAppFromManifest = async (buffer: Buffer) => {
     headers: { Accept: 'application/json', 'Content-Type': 'multipart/form-data' },
     method: HttpMethodTypes.POST,
     body: formData,
-    timeout: TIME_IN_MILLISECONDS.SECOND * 30,
+    timeout: TIME_IN_MILLISECONDS.MINUTE * 2,
   });
   return response;
 };


### PR DESCRIPTION
## Summary

Manifest processing on the API can exceed the previous client timeouts. This change aligns the CLI with slower but successful server responses.

## Changes

- **Import** (`mapps manifest:import`): HTTP timeout for create/update manifest upload increased from **30s** to **2 minutes**.
- **Export** (`mapps manifest:export`): HTTP timeout for validate (POST) and download (GET) increased from the default **10s** to **1 minute**.
- **Version**: patch bump to **4.10.7**.

## Notes

Per-request timeouts still apply per axios attempt; `axios-retry` may retry eligible failures as before.

Made with [Cursor](https://cursor.com)