### PR TITLE
fix: remove postinstall wrapper dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "patch-package": "^8.0.0",
     "pino": "^8.14.1",
     "pino-pretty": "^10.0.1",
-    "postinstall-postinstall": "^2.1.0",
     "pusher-js": "~8.4.3",
     "update-notifier": "^6.0.2",
     "zod": "^3.20.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8084,11 +8084,6 @@ pluralize@^8.0.0:
   resolved "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz"
   integrity sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==
 
-postinstall-postinstall@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/postinstall-postinstall/-/postinstall-postinstall-2.1.0.tgz"
-  integrity sha512-7hQX6ZlZXIoRiWNrbMQaLzUUfH+sSx39u8EJ9HYuDc1kLo9IXKWjM5RSquZN1ad5GnH8CGFM78fsAAQi3OKEEQ==
-
 preferred-pm@^3.0.3:
   version "3.1.2"
   resolved "https://registry.npmjs.org/preferred-pm/-/preferred-pm-3.1.2.tgz"


### PR DESCRIPTION
## Summary

- remove the `postinstall-postinstall` runtime dependency from the published CLI package
- keep the existing package `postinstall` script as `patch-package`, so npm still applies the package patches during install without the extra wrapper re-running the script through Yarn/npm

This is aimed at #146. I could not reproduce the published global install failure in a clean Windows temp prefix, but the stack in the issue points at `node_modules/postinstall-postinstall/run.js`; removing that wrapper keeps the install path simpler while preserving the package's own patch step.

## Verification

- `yarn build`
- `npm pack --ignore-scripts --pack-destination ..\artifacts\pack`
- `npm install --prefix ..\artifacts\npm-prefix-fixed -g ..\artifacts\pack\mondaycom-apps-cli-4.10.8.tgz`
- installed package check confirmed `postinstall-postinstall` is not installed
- `..\artifacts\npm-prefix-fixed\mapps.cmd --version`
- `git diff --check`

I also tried `yarn test --runInBand`, but one `create` test failed in my local Windows run while doing a live template clone and comparing spinner output (`>` vs `✔`), so I did not count that as verification for this packaging-only change.

This was implemented with Codex assistance, with the final diff manually reviewed and kept focused.
