### PR TITLE
fix: correct stale -u flag in scheduler docs USAGE synopsis

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,7 +641,7 @@ Create a new scheduler job for an app
 ```
 USAGE
   $ mapps scheduler:create [--verbose] [--print-command] [-a <value>] [-n <value>] [-z us|eu|au] [-d <value>] [-s
-    <value>] [-u <value>] [-r <value>] [-b <value>] [-t <value>]
+    <value>] [-e <value>] [-r <value>] [-b <value>] [-t <value>]
 
 FLAGS
   -a, --appId=<value>               Please enter app id:
@@ -757,7 +757,7 @@ Update a scheduler job for an app
 ```
 USAGE
   $ mapps scheduler:update [--verbose] [--print-command] [-a <value>] [-n <value>] [-z us|eu|au] [-d <value>] [-s
-    <value>] [-u <value>] [-r <value>] [-b <value>] [-t <value>]
+    <value>] [-e <value>] [-r <value>] [-b <value>] [-t <value>]
 
 FLAGS
   -a, --appId=<value>               Please enter app id:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaycom/apps-cli",
-  "version": "4.10.8",
+  "version": "4.10.9",
   "description": "A cli tool to manage apps (and monday-code projects) in monday.com",
   "author": "monday.com Apps Team",
   "type": "module",


### PR DESCRIPTION
## Summary

A customer reported that the `scheduler:create` docs example didn't match the actual CLI. Investigation confirmed the flag was renamed `-u` → `-e/--targetUrl`, but the README's auto-generated USAGE synopsis was never regenerated and still showed the stale `-u`. The FLAGS and EXAMPLES sections were already correct, so this was an internal inconsistency.

This PR fixes the stale synopsis lines for both `scheduler:create` and `scheduler:update`:

- `scheduler:create` USAGE: `[-u <value>]` → `[-e <value>]`
- `scheduler:update` USAGE: `[-u <value>]` → `[-e <value>]`
- Bump patch version `4.10.8` → `4.10.9`

## Notes

- The public developer docs page ([Schedule cron jobs in monday code](https://developer.monday.com/apps/docs/schedule-cron-jobs-in-monday-code)) had the same issue in its example (`-u "/my-endpoint"` with a leading slash, and `-r 3` where `-r` is actually `--maxRetries` not region) — that page is owned outside this repo and has been corrected separately.
- The separately reported "Unknown error" on interactive-prompt/timeout during create is a real CLI behavior bug, intentionally **not** included here — it's tracked as a follow-up.

## Test plan

- [ ] Confirm `scheduler:create`/`scheduler:update` USAGE synopsis matches FLAGS/EXAMPLES and `mapps scheduler:create --help`

Made with [Cursor](https://cursor.com)